### PR TITLE
Feat[#4]: 프로토타입대로 다이어리 작성 단계 구현

### DIFF
--- a/Ahttiary.xcodeproj/project.pbxproj
+++ b/Ahttiary.xcodeproj/project.pbxproj
@@ -13,8 +13,11 @@
 		7AD34AB4288F933000E92B73 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7AD34AB3288F933000E92B73 /* Preview Assets.xcassets */; };
 		7AD34AC2288F947700E92B73 /* Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AD34AC1288F947700E92B73 /* Model.swift */; };
 		7AD34AC4288F94CF00E92B73 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AD34AC3288F94CF00E92B73 /* ViewModel.swift */; };
+		F8C7A185289EAFCF0000697B /* WriteNoteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8C7A184289EAFCF0000697B /* WriteNoteView.swift */; };
+		F8C7A187289EAFE60000697B /* CheckPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8C7A186289EAFE60000697B /* CheckPageView.swift */; };
+		F8C7A189289EB0C70000697B /* EndPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8C7A188289EB0C70000697B /* EndPageView.swift */; };
 		F8C8A08128998F4F0087C00D /* ScreenSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8C8A08028998F4F0087C00D /* ScreenSize.swift */; };
-		F8C8A083289A26E40087C00D /* WriteNoteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8C8A082289A26E40087C00D /* WriteNoteView.swift */; };
+		F8C8A083289A26E40087C00D /* WritePageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8C8A082289A26E40087C00D /* WritePageView.swift */; };
 		F8C8A085289A2AE20087C00D /* NoteManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8C8A084289A2AE20087C00D /* NoteManager.swift */; };
 		F8C8A087289A2FB90087C00D /* Color+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8C8A086289A2FB90087C00D /* Color+Extensions.swift */; };
 		F8C8A089289A326D0087C00D /* DateFormatter+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8C8A088289A326D0087C00D /* DateFormatter+Extensions.swift */; };
@@ -28,8 +31,11 @@
 		7AD34AB3288F933000E92B73 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		7AD34AC1288F947700E92B73 /* Model.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Model.swift; sourceTree = "<group>"; };
 		7AD34AC3288F94CF00E92B73 /* ViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
+		F8C7A184289EAFCF0000697B /* WriteNoteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteNoteView.swift; sourceTree = "<group>"; };
+		F8C7A186289EAFE60000697B /* CheckPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckPageView.swift; sourceTree = "<group>"; };
+		F8C7A188289EB0C70000697B /* EndPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndPageView.swift; sourceTree = "<group>"; };
 		F8C8A08028998F4F0087C00D /* ScreenSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenSize.swift; sourceTree = "<group>"; };
-		F8C8A082289A26E40087C00D /* WriteNoteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteNoteView.swift; sourceTree = "<group>"; };
+		F8C8A082289A26E40087C00D /* WritePageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WritePageView.swift; sourceTree = "<group>"; };
 		F8C8A084289A2AE20087C00D /* NoteManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteManager.swift; sourceTree = "<group>"; };
 		F8C8A086289A2FB90087C00D /* Color+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Extensions.swift"; sourceTree = "<group>"; };
 		F8C8A088289A326D0087C00D /* DateFormatter+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter+Extensions.swift"; sourceTree = "<group>"; };
@@ -104,10 +110,13 @@
 			children = (
 				7AD34AAE288F932E00E92B73 /* ContentView.swift */,
 				F8C8A08028998F4F0087C00D /* ScreenSize.swift */,
-				F8C8A082289A26E40087C00D /* WriteNoteView.swift */,
+				F8C8A082289A26E40087C00D /* WritePageView.swift */,
 				F8C8A084289A2AE20087C00D /* NoteManager.swift */,
 				F8C8A086289A2FB90087C00D /* Color+Extensions.swift */,
 				F8C8A088289A326D0087C00D /* DateFormatter+Extensions.swift */,
+				F8C7A184289EAFCF0000697B /* WriteNoteView.swift */,
+				F8C7A186289EAFE60000697B /* CheckPageView.swift */,
+				F8C7A188289EB0C70000697B /* EndPageView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -183,11 +192,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				F8C8A08128998F4F0087C00D /* ScreenSize.swift in Sources */,
+				F8C7A189289EB0C70000697B /* EndPageView.swift in Sources */,
 				7AD34AC4288F94CF00E92B73 /* ViewModel.swift in Sources */,
 				F8C8A087289A2FB90087C00D /* Color+Extensions.swift in Sources */,
+				F8C7A185289EAFCF0000697B /* WriteNoteView.swift in Sources */,
 				F8C8A089289A326D0087C00D /* DateFormatter+Extensions.swift in Sources */,
+				F8C7A187289EAFE60000697B /* CheckPageView.swift in Sources */,
 				7AD34AAF288F932E00E92B73 /* ContentView.swift in Sources */,
-				F8C8A083289A26E40087C00D /* WriteNoteView.swift in Sources */,
+				F8C8A083289A26E40087C00D /* WritePageView.swift in Sources */,
 				F8C8A085289A2AE20087C00D /* NoteManager.swift in Sources */,
 				7AD34AAD288F932E00E92B73 /* AhttiaryApp.swift in Sources */,
 				7AD34AC2288F947700E92B73 /* Model.swift in Sources */,

--- a/Ahttiary/Views/CheckPageView.swift
+++ b/Ahttiary/Views/CheckPageView.swift
@@ -40,18 +40,17 @@ struct CheckPageView: View {
                     Button("계속 쓸래") {
                         noteManager.goToNextPage()
                     }
-                    .buttonStyle(.bordered)
+                    
                     Button("오늘은 여기까지만") {
                         noteManager.goToLastPage()
                     }
-                    .buttonStyle(.bordered)
                 } else {
                     Button("다 썼다~") {
                         noteManager.goToLastPage()
                     }
-                    .buttonStyle(.bordered)
                 }
             }
+            .buttonStyle(.bordered)
             
             Spacer()
         }
@@ -59,6 +58,7 @@ struct CheckPageView: View {
         .toolbar {
             ToolbarItemGroup(placement: .keyboard) {
                 Spacer()
+                
                 Button {
                     isTextFieldsFocused = false
                 } label: {

--- a/Ahttiary/Views/CheckPageView.swift
+++ b/Ahttiary/Views/CheckPageView.swift
@@ -1,0 +1,71 @@
+//
+//  CheckNoteView.swift
+//  Ahttiary
+//
+//  Created by 임성균 on 2022/08/06.
+//
+
+import SwiftUI
+
+struct CheckPageView: View {
+    @ObservedObject var noteManager: NoteManager
+    
+    @FocusState var isTextFieldsFocused: Bool
+    
+    var isWritingFinished: Bool
+    
+    var body: some View {
+        VStack {
+            Spacer()
+            
+            // 아띠와 말풍선
+            HStack(alignment: .center) {
+                Image("AhttyWriter")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: ScreenSize.ahttyWriterWidth)
+                
+                Text(noteManager.questionInPresentPage)
+                    .frame(
+                        height: ScreenSize.questionMessageBoxHeight,
+                        alignment: .center
+                    )
+                    .background(Color.Custom.ahttyWhite)
+                    .cornerRadius(15)
+                    .padding()
+            }
+            
+            VStack {
+                if !isWritingFinished {
+                    Button("계속 쓸래") {
+                        noteManager.goToNextPage()
+                    }
+                    .buttonStyle(.bordered)
+                    Button("오늘은 여기까지만") {
+                        noteManager.goToLastPage()
+                    }
+                    .buttonStyle(.bordered)
+                } else {
+                    Button("다 썼다~") {
+                        noteManager.goToLastPage()
+                    }
+                    .buttonStyle(.bordered)
+                }
+            }
+            
+            Spacer()
+        }
+        .background(Color.Custom.backgroundColor.ignoresSafeArea())
+        .toolbar {
+            ToolbarItemGroup(placement: .keyboard) {
+                Spacer()
+                Button {
+                    isTextFieldsFocused = false
+                } label: {
+                    Image(systemName: "keyboard.chevron.compact.down")
+                }
+                
+            }
+        }
+    }
+}

--- a/Ahttiary/Views/EndPageView.swift
+++ b/Ahttiary/Views/EndPageView.swift
@@ -1,0 +1,43 @@
+//
+//  EndingNoteView.swift
+//  Ahttiary
+//
+//  Created by 임성균 on 2022/08/06.
+//
+
+import SwiftUI
+
+struct EndPageView: View {
+    @ObservedObject var noteManager: NoteManager
+    
+    var body: some View {
+        VStack {
+            Spacer()
+            
+            // 아띠와 말풍선
+            HStack(alignment: .center) {
+                Image("AhttyWriter")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: ScreenSize.ahttyWriterWidth)
+                
+                Text(noteManager.questionInPresentPage)
+                    .frame(
+                        height: ScreenSize.questionMessageBoxHeight,
+                        alignment: .center
+                    )
+                    .background(Color.Custom.ahttyWhite)
+                    .cornerRadius(15)
+                    .padding()
+            }
+            
+                Button("종료하기") {
+                    noteManager.goToLastPage()
+                }
+                .buttonStyle(.bordered)
+            
+            Spacer()
+        }
+        .background(Color.Custom.backgroundColor.ignoresSafeArea())
+    }
+}

--- a/Ahttiary/Views/NoteManager.swift
+++ b/Ahttiary/Views/NoteManager.swift
@@ -8,22 +8,52 @@
 import Foundation
 
 final class NoteManager: ObservableObject {
-    var answers: [String] = ["첫 번째 대답", "두 번째 대답"]
+    // TODO: 샘플 데이터입니다. UI 작업 끝나고 CoreData로 대체하겠습니다.
+    var answers: [String] = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]
+    
     @Published var pageNumber: Int = 0
     
+    // pageNumber에 맞는 페이지의 질문을 쉽게 불러오기 위한 변수입니다.
+    var questionInPresentPage: String { NoteManager.questions[pageNumber] }
+    
     static let questions: [String] = [
+        // 0. 상황 서술
         """
         이전에 느꼈던 감정을 다시
         떠올리곤 해. 만약 다르게
         받아들였다면 나는 달라졌을까?
         오늘 너에게는 어떤 일이 있었니?
         """,
+        // 1. 감정 서술
         """
         그런 일이 있었구나,
         어떤 기분이 들었니?
         얼마나 큰 영향을 미쳤니?
         """,
-        
+        // 2. 첫번째 감정 인식
+        """
+        감정 선택 페이지 1
+        """,
+        // 3. 자동적 사고
+        """
+        자동적 사고
+        """,
+        // 4. 인지 왜곡 파악
+        """
+        인지 왜곡 파악
+        """,
+        // 5. 합리적 반응 도출
+        """
+        합리적 반응 도출
+        """,
+        // 6. 두번째 감정 인식
+        """
+        감정 선택 페이지 2
+        """,
+        // 7. 마지막 페이지
+        """
+        멘트 후 종료
+        """
     ]
     
     func goToNextPage() {
@@ -36,5 +66,9 @@ final class NoteManager: ObservableObject {
         if pageNumber != 0 {
             pageNumber += -1
         }
+    }
+    
+    func goToLastPage() {
+        pageNumber = 7
     }
 }

--- a/Ahttiary/Views/WriteNoteView.swift
+++ b/Ahttiary/Views/WriteNoteView.swift
@@ -10,79 +10,37 @@ import SwiftUI
 struct WriteNoteView: View {
     @ObservedObject var noteManager: NoteManager = NoteManager()
     
-    @FocusState var isTextFieldsFocused: Bool
-    
     var body: some View {
-        VStack {
-            // 아띠와 말풍선
-            HStack(alignment: .center) {
-                Image("AhttyWriter")
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(width: ScreenSize.ahttyWriterWidth)
-                
-                Text(NoteManager.questions[noteManager.pageNumber])
-                    .frame(
-                        height: ScreenSize.questionMessageBoxHeight,
-                        alignment: .center
-                    )
-                    .background(Color.Custom.ahttyWhite)
-                    .cornerRadius(15)
-                    .padding()
-            }
+        switch noteManager.pageNumber {
             
-            HStack {
-                Text(DateFormatter.getKoreanDateInString())
-                
-                Spacer()
-                
-                Text("맑음")
-            }
-            .padding(.horizontal)
-            .font(.callout)
-            .foregroundColor(.gray)
+        case 0...1:
+            // 상황, 정서
+            WritePageView(noteManager: noteManager)
             
-            // 노트 작성란
-            HStack {
-                TextEditor(text: $noteManager.answers[noteManager.pageNumber])
-                    .frame(
-                        height: ScreenSize.answerMessageBoxHeight
-                    )
-                    .background(Color.Custom.ahttyWhite)
-                    .cornerRadius(15)
-                    .padding()
-                    .focused($isTextFieldsFocused)
-            }
+        case 2:
+            // 감정 체크 및 다이어리 추가 작성 여부 선택
+            CheckPageView(noteManager: noteManager, isWritingFinished: false)
             
-            HStack {
-                Button("이전") {
-                    noteManager.goToPreviousPage()
-                }
-                .buttonStyle(.bordered)
-                Button("다음") {
-                    noteManager.goToNextPage()
-                }
-                .buttonStyle(.bordered)
-            }
+        case 3...5:
+            // 다이어리 추가 작성 (자동적 사고 기술, 인지 왜곡 파악, 합리적 반응 도출)
+            WritePageView(noteManager: noteManager)
             
-            Spacer()
-        }
-        .background(Color.Custom.backgroundColor.ignoresSafeArea())
-        .toolbar {
-            ToolbarItemGroup(placement: .keyboard) {
-                Spacer()
-                Button {
-                    isTextFieldsFocused = false
-                } label: {
-                    Image(systemName: "keyboard.chevron.compact.down")
-                }
-                
-            }
+        case 6:
+            // 감정 체크 및 페이지 넘어가기
+            CheckPageView(noteManager: noteManager, isWritingFinished: true)
+            
+        case 7:
+            // 마지막 페이지(내일도 즐거운 하루 보내자!)
+            EndPageView(noteManager: noteManager)
+            
+        default:
+            // ErrorPageView()
+            EmptyView()
         }
     }
 }
 
-struct WriteNoteView_Previews: PreviewProvider {
+struct WritingView_Previews: PreviewProvider {
     static var previews: some View {
         WriteNoteView()
     }

--- a/Ahttiary/Views/WritePageView.swift
+++ b/Ahttiary/Views/WritePageView.swift
@@ -1,0 +1,89 @@
+//
+//  WriteNoteView.swift
+//  Ahttiary
+//
+//  Created by 임성균 on 2022/08/03.
+//
+
+import SwiftUI
+
+struct WritePageView: View {
+    @ObservedObject var noteManager: NoteManager = NoteManager()
+    
+    @FocusState var isTextFieldsFocused: Bool
+    
+    var body: some View {
+        VStack {
+            // 아띠와 말풍선
+            HStack(alignment: .center) {
+                Image("AhttyWriter")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: ScreenSize.ahttyWriterWidth)
+                
+                Text(NoteManager.questions[noteManager.pageNumber])
+                    .frame(
+                        height: ScreenSize.questionMessageBoxHeight,
+                        alignment: .center
+                    )
+                    .background(Color.Custom.ahttyWhite)
+                    .cornerRadius(15)
+                    .padding()
+            }
+            
+            HStack {
+                Text(DateFormatter.getKoreanDateInString())
+                
+                Spacer()
+                
+                Text("맑음")
+            }
+            .padding(.horizontal)
+            .font(.callout)
+            .foregroundColor(.gray)
+            
+            // 노트 작성란
+            HStack {
+                TextEditor(text: $noteManager.answers[noteManager.pageNumber])
+                    .frame(
+                        height: ScreenSize.answerMessageBoxHeight
+                    )
+                    .background(Color.Custom.ahttyWhite)
+                    .cornerRadius(15)
+                    .padding()
+                    .focused($isTextFieldsFocused)
+            }
+            
+            HStack {
+                Button("이전") {
+                    noteManager.goToPreviousPage()
+                }
+                .buttonStyle(.bordered)
+                Button("다음") {
+                    noteManager.goToNextPage()
+                }
+                .buttonStyle(.bordered)
+            }
+            
+            Spacer()
+        }
+        .background(Color.Custom.backgroundColor.ignoresSafeArea())
+        .toolbar {
+            ToolbarItemGroup(placement: .keyboard) {
+                Spacer()
+                Button {
+                    isTextFieldsFocused = false
+                } label: {
+                    Image(systemName: "keyboard.chevron.compact.down")
+                }
+                
+            }
+        }
+    }
+}
+
+struct WriteNoteView_Previews: PreviewProvider {
+    static var previews: some View {
+        WritePageView()
+    }
+}

--- a/Ahttiary/Views/WritePageView.swift
+++ b/Ahttiary/Views/WritePageView.swift
@@ -1,5 +1,5 @@
 //
-//  WriteNoteView.swift
+//  WritePageView.swift
 //  Ahttiary
 //
 //  Created by 임성균 on 2022/08/03.

--- a/Ahttiary/Views/WritePageView.swift
+++ b/Ahttiary/Views/WritePageView.swift
@@ -58,12 +58,12 @@ struct WritePageView: View {
                 Button("이전") {
                     noteManager.goToPreviousPage()
                 }
-                .buttonStyle(.bordered)
+                
                 Button("다음") {
                     noteManager.goToNextPage()
                 }
-                .buttonStyle(.bordered)
             }
+            .buttonStyle(.bordered)
             
             Spacer()
         }
@@ -71,6 +71,7 @@ struct WritePageView: View {
         .toolbar {
             ToolbarItemGroup(placement: .keyboard) {
                 Spacer()
+                
                 Button {
                     isTextFieldsFocused = false
                 } label: {


### PR DESCRIPTION
## 작업 내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- 프로토타입 앱 흐름을 구현했습니다.
  - CheckPageView: 감정 기록을 마친 뒤, 자신의 감정을 인식하면서 이후 단계를 진행할지를 결정합니다. 
  - CheckPageView: 감정 기록이 끝났을 때도 다시 한번 감정을 인식하며 얼마나 개선되었는지 확인합니다.
  - EndPageView: CheckPageView 다음에 나오는 페이지입니다. 다이어리 작성이 끝났음을 알려줍니다.
  - WriteNoteView: 사용자의 선택에 따른 PageView를 보여줍니다. 

## 리뷰 포인트
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->
- 다이어리 작성의 흐름을 관리하는 View는 WriteNoteView로, 노트의 각 페이지를 구성하는 View는 ~PageView로 이름 붙였습니다. 이후 파일명, 변수명에 대한 합의가 필요합니다.

## 질문
<!-- PR 과정에서 생긴 질문을 적어주세요. -->
- 

## 다음 진행할 작업
- 디자인 반영
- 각 단계에 들어갈 문장 다듬기
- Main(Calendar)와 연결
- 더미 데이터를 코어데이터로 대체

## 참고한 자료
<!-- 참고한 코드의 출처를 작성해주세요 -->
-
