### PR TITLE
Feat[#7] CalendarView / CoreData 연결 기본 구조 세팅

### DIFF
--- a/Ahttiary.xcodeproj/project.pbxproj
+++ b/Ahttiary.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		7AD34AB1288F933000E92B73 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7AD34AB0288F933000E92B73 /* Assets.xcassets */; };
 		7AD34AB4288F933000E92B73 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7AD34AB3288F933000E92B73 /* Preview Assets.xcassets */; };
 		7AD34AC2288F947700E92B73 /* Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AD34AC1288F947700E92B73 /* Model.swift */; };
+		8906A86C28ADE19400C1E254 /* MainViewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8906A86B28ADE19400C1E254 /* MainViewManager.swift */; };
 		8981172A28A664B200BAB3E2 /* AhttyComment.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 8981172928A664B200BAB3E2 /* AhttyComment.ttf */; };
 		8981172C28A6663200BAB3E2 /* Font.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8981172B28A6663200BAB3E2 /* Font.swift */; };
 		8981172E28A6672000BAB3E2 /* GangwonEduAllBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 8981172D28A6672000BAB3E2 /* GangwonEduAllBold.otf */; };
@@ -59,6 +60,7 @@
 		7AD34AB0288F933000E92B73 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		7AD34AB3288F933000E92B73 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		7AD34AC1288F947700E92B73 /* Model.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Model.swift; sourceTree = "<group>"; };
+		8906A86B28ADE19400C1E254 /* MainViewManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewManager.swift; sourceTree = "<group>"; };
 		8981172928A664B200BAB3E2 /* AhttyComment.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = AhttyComment.ttf; sourceTree = "<group>"; };
 		8981172B28A6663200BAB3E2 /* Font.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Font.swift; sourceTree = "<group>"; };
 		8981172D28A6672000BAB3E2 /* GangwonEduAllBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = GangwonEduAllBold.otf; sourceTree = "<group>"; };
@@ -160,6 +162,7 @@
 				7A1709342898D309001E98D5 /* DateViewModel.swift */,
 				7A3BA309289C0B9B002ABB95 /* CalendarViewModel.swift */,
 				F8622D1C28AA9C4D008908CB /* NoteManager.swift */,
+				8906A86B28ADE19400C1E254 /* MainViewManager.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -318,6 +321,7 @@
 				F8622D1728AA9C3B008908CB /* NSManagedObject.swift in Sources */,
 				F8622D1928AA9C3B008908CB /* Note.swift in Sources */,
 				7AD34AAD288F932E00E92B73 /* AhttiaryApp.swift in Sources */,
+				8906A86C28ADE19400C1E254 /* MainViewManager.swift in Sources */,
 				7AD34AC2288F947700E92B73 /* Model.swift in Sources */,
 				7A3BA2FB289ABB9A002ABB95 /* CurrentMonthView.swift in Sources */,
 				7A3BA30E289C0FD0002ABB95 /* MonthStruct.swift in Sources */,

--- a/Ahttiary/AhttiaryApp.swift
+++ b/Ahttiary/AhttiaryApp.swift
@@ -12,11 +12,13 @@ struct AhttiaryApp: App {
     
     @StateObject var persistentStore = PersistentStore.shared
     @StateObject var dateViewModel: DateViewModel = DateViewModel()
+    @StateObject var mainViewManager: MainViewManager = MainViewManager()
     
     var body: some Scene {
         WindowGroup {
-            MainView()
+            ContentView()
                 .environmentObject(dateViewModel)
+                .environmentObject(mainViewManager)
                 .environment(\.managedObjectContext, persistentStore.context)
         }
     }

--- a/Ahttiary/ViewModels/DateViewModel.swift
+++ b/Ahttiary/ViewModels/DateViewModel.swift
@@ -25,7 +25,7 @@ final class DateViewModel: ObservableObject {
     func updateSelectedDate(_ selectedDay: Int) {
         let originalDay = Calendar.current.dateComponents([.day], from: date).day!
         guard let changedDate = Calendar.current.date(byAdding: .day, value: selectedDay - originalDay, to: date) else { return }
-                
+        print("✅ 캘린더에서 선택된 날짜: \(changedDate)")
         self.selectedDate = changedDate
     }
     

--- a/Ahttiary/ViewModels/DateViewModel.swift
+++ b/Ahttiary/ViewModels/DateViewModel.swift
@@ -10,7 +10,6 @@ import Foundation
 final class DateViewModel: ObservableObject {
     @Published var date: Date = Date()
     @Published var selectedDate: Date = Date()
-    static let shared = DateViewModel()
     
     func fetchPreviousMonth() {
         guard let previousMonth = CalendarViewModel().getPreviousMonth(date) else { return }

--- a/Ahttiary/ViewModels/MainViewManager.swift
+++ b/Ahttiary/ViewModels/MainViewManager.swift
@@ -1,0 +1,35 @@
+//
+//  MainViewManager.swift
+//  Ahttiary
+//
+//  Created by Hyeon-sang Lee on 2022/08/18.
+//
+
+import Foundation
+import SwiftUI
+
+final class MainViewManager: ObservableObject {
+    @Published var pageNumber: Int = 0
+    @Published var note: FetchedResults<Note>.Element? = nil
+    
+    func goToMainView() {
+        withAnimation {
+            pageNumber = 0
+        }
+    }
+
+    func goToWritingView() {
+        withAnimation {
+            pageNumber = 1
+        }
+    }
+    
+    func goToReadingView() {
+        withAnimation {
+            pageNumber = 2
+        }
+    }
+        
+    func updateNote(_ data: FetchedResults<Note>.Element) { self.note = data }
+    
+}// MainViewManager

--- a/Ahttiary/ViewModels/MainViewManager.swift
+++ b/Ahttiary/ViewModels/MainViewManager.swift
@@ -9,27 +9,40 @@ import Foundation
 import SwiftUI
 
 final class MainViewManager: ObservableObject {
-    @Published var pageNumber: Int = 0
+    @Published var pageName: PageName = .main
     @Published var note: FetchedResults<Note>.Element? = nil
     
     func goToMainView() {
         withAnimation {
-            pageNumber = 0
+            pageName = .main
         }
     }
 
     func goToWritingView() {
         withAnimation {
-            pageNumber = 1
+            pageName = .writing
         }
     }
     
     func goToReadingView() {
         withAnimation {
-            pageNumber = 2
+            pageName = .reading
         }
     }
         
     func updateNote(_ data: FetchedResults<Note>.Element?) { self.note = data }
     
+    func createNote(_ createdDate: Date = Date()) -> some View {
+        print("🔥 해당 날짜로 다이어리가 생성됩니다: \(createdDate)")
+        let newNote = Note.getNewNote(createdDate)
+
+        return WriteNoteView(note: newNote)
+    }
+    
 }// MainViewManager
+
+enum PageName {
+    case main
+    case writing
+    case reading
+}

--- a/Ahttiary/ViewModels/MainViewManager.swift
+++ b/Ahttiary/ViewModels/MainViewManager.swift
@@ -30,6 +30,6 @@ final class MainViewManager: ObservableObject {
         }
     }
         
-    func updateNote(_ data: FetchedResults<Note>.Element) { self.note = data }
+    func updateNote(_ data: FetchedResults<Note>.Element?) { self.note = data }
     
 }// MainViewManager

--- a/Ahttiary/Views/Calendar/CalendarCell.swift
+++ b/Ahttiary/Views/Calendar/CalendarCell.swift
@@ -16,12 +16,15 @@ struct CalendarCell: View {
     let startingPosition: Int
     let totalDaysInMonth: Int
     let totalDaysInPreviousMonth: Int
+    var dayOfThisCell: Int {
+        return fetchMonthStruct().dayInt
+    }
     
     var body: some View {
         if fetchMonthStruct().monthType == .current {
             ZStack {
                 Circle()
-                    .foregroundColor(dateManager.verifySelectedDay(fetchMonthStruct().dayInt) ? Color.Custom.carrotGreen : .clear)
+                    .foregroundColor(dateManager.verifySelectedDay(dayOfThisCell) ? Color.Custom.carrotGreen : .clear)
                 
                 Text(fetchMonthStruct().day())
                     .font(.custom(Font.shared.calendarBold, size: 20))
@@ -29,19 +32,18 @@ struct CalendarCell: View {
                     .foregroundColor(
                         detectNoteData()
                         ? .Custom.carrot
-                        : dateManager.verifySelectedDay(fetchMonthStruct().dayInt)
+                        : dateManager.verifySelectedDay(dayOfThisCell)
                             ? .white
-                            : dateManager.verifyFutureDate(fetchMonthStruct().dayInt)
+                            : dateManager.verifyFutureDate(dayOfThisCell)
                                 ? .gray
                                 : .black
-                        
                     )
                     .onTapGesture {
                         withAnimation {
-                            dateManager.updateSelectedDate(fetchMonthStruct().dayInt)
+                            dateManager.updateSelectedDate(dayOfThisCell)
                         }
                     }
-                    .disabled(dateManager.verifyFutureDate(fetchMonthStruct().dayInt))
+                    .disabled(dateManager.verifyFutureDate(dayOfThisCell))
                 
             }
         } else {
@@ -71,13 +73,14 @@ struct CalendarCell: View {
             guard let dateCreated = note.dateCreated_ else { return false }
             let createdDateOfNote = DateFormatter.convertToKoreanDate(date: dateCreated)
             var dateOfCell: String {
-                let year = fetchMonthStruct().yearInfo!
-                let month = String(format: "%02d" , fetchMonthStruct().monthInfo!)
-                let day = fetchMonthStruct().dayInt
+                let components = Calendar.current.dateComponents([.year, .month], from: dateManager.date)
+                let year = components.year!
+                let month = String(format: "%02d" , components.month!)
+                let day = dayOfThisCell
                 
                 return "\(year)년 \(month)월 \(day)일"
             }
-
+            
             if createdDateOfNote == dateOfCell { return true }
         }
         

--- a/Ahttiary/Views/Calendar/CalendarCell.swift
+++ b/Ahttiary/Views/Calendar/CalendarCell.swift
@@ -10,6 +10,8 @@ import SwiftUI
 
 struct CalendarCell: View {
     @EnvironmentObject var dateManager: DateViewModel
+    @FetchRequest(fetchRequest: Note.allNotesFR())
+    var notes: FetchedResults<Note>
     let count: Int
     let startingPosition: Int
     let totalDaysInMonth: Int
@@ -25,11 +27,14 @@ struct CalendarCell: View {
                     .font(.custom(Font.shared.calendarBold, size: 20))
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .foregroundColor(
-                        dateManager.verifySelectedDay(fetchMonthStruct().dayInt)
-                        ? .white
-                        : dateManager.verifyFutureDate(fetchMonthStruct().dayInt)
-                            ? .gray
-                            : .black
+                        detectNoteData()
+                        ? .Custom.carrot
+                        : dateManager.verifySelectedDay(fetchMonthStruct().dayInt)
+                            ? .white
+                            : dateManager.verifyFutureDate(fetchMonthStruct().dayInt)
+                                ? .gray
+                                : .black
+                        
                     )
                     .onTapGesture {
                         withAnimation {
@@ -37,7 +42,7 @@ struct CalendarCell: View {
                         }
                     }
                     .disabled(dateManager.verifyFutureDate(fetchMonthStruct().dayInt))
-
+                
             }
         } else {
             Text("")
@@ -60,7 +65,25 @@ struct CalendarCell: View {
         
         return MonthStruct(monthType: .current, dayInt: day)
     }
+    
+    private func detectNoteData() -> Bool {
+        for note in notes {
+            guard let dateCreated = note.dateCreated_ else { return false }
+            let createdDateOfNote = DateFormatter.convertToKoreanDate(date: dateCreated)
+            var dateOfCell: String {
+                let year = fetchMonthStruct().yearInfo!
+                let month = String(format: "%02d" , fetchMonthStruct().monthInfo!)
+                let day = fetchMonthStruct().dayInt
+                
+                return "\(year)년 \(month)월 \(day)일"
+            }
+
+            if createdDateOfNote == dateOfCell { return true }
+        }
         
+        return false
+    }
+    
 }// CalendarCell
 
 struct CalendarCell_Previews: PreviewProvider {

--- a/Ahttiary/Views/Calendar/CalendarCell.swift
+++ b/Ahttiary/Views/Calendar/CalendarCell.swift
@@ -38,11 +38,14 @@ struct CalendarCell: View {
                                 : .black
                     )
                     .onTapGesture {
-                        withAnimation {
-                            dateManager.updateSelectedDate(dayOfThisCell)
-                        }
+                        withAnimation { dateManager.updateSelectedDate(dayOfThisCell) }
                         if detectNoteData() { linkNoteCoreData() }
                         else { mainViewManager.updateNote(nil)}
+                    }
+                    .onAppear {
+                        if dateManager.verifySelectedDay(dayOfThisCell) {
+                            if detectNoteData() { linkNoteCoreData() }
+                        }
                     }
                     .disabled(dateManager.verifyFutureDate(dayOfThisCell))
             }

--- a/Ahttiary/Views/Calendar/CalendarCell.swift
+++ b/Ahttiary/Views/Calendar/CalendarCell.swift
@@ -10,15 +10,14 @@ import SwiftUI
 
 struct CalendarCell: View {
     @EnvironmentObject var dateManager: DateViewModel
+    @EnvironmentObject var mainViewManager: MainViewManager
     @FetchRequest(fetchRequest: Note.allNotesFR())
     var notes: FetchedResults<Note>
     let count: Int
     let startingPosition: Int
     let totalDaysInMonth: Int
     let totalDaysInPreviousMonth: Int
-    var dayOfThisCell: Int {
-        return fetchMonthStruct().dayInt
-    }
+    var dayOfThisCell: Int { return fetchMonthStruct().dayInt }
     
     var body: some View {
         if fetchMonthStruct().monthType == .current {
@@ -42,9 +41,9 @@ struct CalendarCell: View {
                         withAnimation {
                             dateManager.updateSelectedDate(dayOfThisCell)
                         }
+                        if detectNoteData() { linkNoteCoreData() }
                     }
                     .disabled(dateManager.verifyFutureDate(dayOfThisCell))
-                
             }
         } else {
             Text("")
@@ -85,6 +84,24 @@ struct CalendarCell: View {
         }
         
         return false
+    }
+    
+    private func linkNoteCoreData() {
+        for note in notes {
+            guard let dateCreated = note.dateCreated_ else { return }
+            let createdDateOfNote = DateFormatter.convertToKoreanDate(date: dateCreated)
+            var dateOfCell: String {
+                let components = Calendar.current.dateComponents([.year, .month], from: dateManager.date)
+                let year = components.year!
+                let month = String(format: "%02d" , components.month!)
+                let day = dayOfThisCell
+                
+                return "\(year)년 \(month)월 \(day)일"
+            }
+            
+            if createdDateOfNote == dateOfCell { mainViewManager.updateNote(note) }
+        }
+
     }
     
 }// CalendarCell

--- a/Ahttiary/Views/Calendar/CalendarCell.swift
+++ b/Ahttiary/Views/Calendar/CalendarCell.swift
@@ -42,6 +42,7 @@ struct CalendarCell: View {
                             dateManager.updateSelectedDate(dayOfThisCell)
                         }
                         if detectNoteData() { linkNoteCoreData() }
+                        else { mainViewManager.updateNote(nil)}
                     }
                     .disabled(dateManager.verifyFutureDate(dayOfThisCell))
             }
@@ -87,21 +88,7 @@ struct CalendarCell: View {
     }
     
     private func linkNoteCoreData() {
-        for note in notes {
-            guard let dateCreated = note.dateCreated_ else { return }
-            let createdDateOfNote = DateFormatter.convertToKoreanDate(date: dateCreated)
-            var dateOfCell: String {
-                let components = Calendar.current.dateComponents([.year, .month], from: dateManager.date)
-                let year = components.year!
-                let month = String(format: "%02d" , components.month!)
-                let day = dayOfThisCell
-                
-                return "\(year)년 \(month)월 \(day)일"
-            }
-            
-            if createdDateOfNote == dateOfCell { mainViewManager.updateNote(note) }
-        }
-
+        for note in notes { mainViewManager.updateNote(note) }
     }
     
 }// CalendarCell

--- a/Ahttiary/Views/Calendar/DateGridView.swift
+++ b/Ahttiary/Views/Calendar/DateGridView.swift
@@ -57,7 +57,6 @@ struct DateGridView: View {
                                 totalDaysInMonth: totalDaysInMonth,
                                 totalDaysInPreviousMonth: totalDaysInPreviousMonth
                             )
-                            .environmentObject(dateManager)
                         }
                     }
                 }

--- a/Ahttiary/Views/Calendar/DateGridView.swift
+++ b/Ahttiary/Views/Calendar/DateGridView.swift
@@ -9,16 +9,24 @@ import SwiftUI
 
 struct DateGridView: View {
     @EnvironmentObject var dateManager: DateViewModel
+    @State private var locationOfGrid: CGFloat = 0
     
     var body: some View {
         VStack {
             dayOfWeek
             calendarGrid
+                .offset(x: locationOfGrid)
         }
-        .gesture(DragGesture(minimumDistance: 0, coordinateSpace: .local).onEnded({ value in
-            if value.translation.width < 0 { dateManager.fetchNextMonth() }
-            if value.translation.width > 0 { dateManager.fetchPreviousMonth() }
-        }))
+        .gesture(DragGesture(minimumDistance: 0, coordinateSpace: .local)
+            .onChanged {
+                locationOfGrid = $0.translation.width
+            }
+            .onEnded {
+                if $0.translation.width < 0 { dateManager.fetchNextMonth() }
+                if $0.translation.width > 0 { dateManager.fetchPreviousMonth() }
+                locationOfGrid = 0
+            }
+        )
     }// body
     
     private var dayOfWeek: some View {

--- a/Ahttiary/Views/ContentView.swift
+++ b/Ahttiary/Views/ContentView.swift
@@ -9,22 +9,25 @@ import SwiftUI
 
 struct ContentView: View {
     @EnvironmentObject var mainViewManager: MainViewManager
+    @EnvironmentObject var dateManager: DateViewModel
     @FetchRequest(fetchRequest: Note.allNotesFR())
     private var notes: FetchedResults<Note>
     
     var body: some View {
-        switch (mainViewManager.pageNumber) {
-        case 0:
+        contentView
+    }// body
+    
+    @ViewBuilder private var contentView: some View {
+        switch (mainViewManager.pageName) {
+        case .main:
             MainView()
-        case 1:
-            TemporaryListView()
-        case 2:
+        case .writing:
+            mainViewManager.createNote(dateManager.selectedDate)
+        case .reading:
             WriteNoteView(note: mainViewManager.note!)
-        default:
-            MainView()
         }
-        
-    }// body    
+    }
+    
 }// ContentView
 
 struct ContentView_Previews: PreviewProvider {

--- a/Ahttiary/Views/ContentView.swift
+++ b/Ahttiary/Views/ContentView.swift
@@ -8,16 +8,23 @@
 import SwiftUI
 
 struct ContentView: View {
+    @EnvironmentObject var mainViewManager: MainViewManager
+    @FetchRequest(fetchRequest: Note.allNotesFR())
+    private var notes: FetchedResults<Note>
+    
     var body: some View {
-        VStack {
-            Image("ahtty")
-                .resizable()
-                .frame(width: 300, height: 300)
-                
-            Text("하루의 끝 당신의 곁엔 아띠가 있어요.")
-                .padding()
+        switch (mainViewManager.pageNumber) {
+        case 0:
+            MainView()
+        case 1:
+            TemporaryListView()
+        case 2:
+            WriteNoteView(note: mainViewManager.note!)
+        default:
+            MainView()
         }
-    }// body
+        
+    }// body    
 }// ContentView
 
 struct ContentView_Previews: PreviewProvider {

--- a/Ahttiary/Views/MainView.swift
+++ b/Ahttiary/Views/MainView.swift
@@ -8,6 +8,12 @@
 import SwiftUI
 
 struct MainView: View {
+    @EnvironmentObject var mainViewManager: MainViewManager
+    var buttonText: String {
+        if mainViewManager.note == nil { return "감정기록 시작하기" }
+        return "감정 읽기"
+    }
+    
     var body: some View {
         VStack {
             CalendarView()
@@ -27,13 +33,14 @@ struct MainView: View {
             .padding(.bottom, 90)
             
             Button {
-                print("Hello")
+                if mainViewManager.note == nil { return mainViewManager.goToWritingView() }
+                mainViewManager.goToReadingView()
             } label: {
                 ZStack (alignment: .center) {
                     RoundedRectangle(cornerRadius: 10)
                         .foregroundColor(Color.Custom.carrotGreen)
                     
-                    Text("감정기록 시작하기")
+                    Text(buttonText)
                         .font(.custom(Font.shared.calendarBold, size: 20))
                         .foregroundColor(.white)
                 }

--- a/Ahttiary/Views/MainView.swift
+++ b/Ahttiary/Views/MainView.swift
@@ -33,7 +33,7 @@ struct MainView: View {
             .padding(.bottom, 90)
             
             Button {
-                if mainViewManager.note == nil { return mainViewManager.goToWritingView() }
+                if mainViewManager.note == nil { mainViewManager.goToWritingView() }
                 mainViewManager.goToReadingView()
             } label: {
                 ZStack (alignment: .center) {

--- a/Ahttiary/Views/MainView.swift
+++ b/Ahttiary/Views/MainView.swift
@@ -34,7 +34,7 @@ struct MainView: View {
             
             Button {
                 if mainViewManager.note == nil { mainViewManager.goToWritingView() }
-                mainViewManager.goToReadingView()
+                else { mainViewManager.goToReadingView() }
             } label: {
                 ZStack (alignment: .center) {
                     RoundedRectangle(cornerRadius: 10)


### PR DESCRIPTION
## 작업 내용
- 캘린더 상에서 코어데이터가 표시되는 기본 구조를 세팅했습니다.
- 각 날짜의 데이터 유무에 따라 기록 작성/열람이 가능하도록 구성했습니다.

## 리뷰 포인트
- 뷰 변경은 contentView 파일에서 switch 구문을 통해 진행되도록 했습니다.
- 기록 작성의 경우 현재 임시리스트 파일과 연결되어 있어 차후 적합한 파일로 재연결할 필요가 있습니다.

## 질문
- 특이사항 없음

## 다음 진행할 작업
- 진행과정에서 발견되는 버그 수정

## 참고한 자료
- 특이사항 없음
